### PR TITLE
fix(db): remove unsupported 'journal_mode' pragma to prevent crash

### DIFF
--- a/src/turbo_tosec/database.py
+++ b/src/turbo_tosec/database.py
@@ -26,7 +26,6 @@ class DatabaseManager:
     def connect(self):
         """Establishes connection and ensures schema exists."""
         self.conn = duckdb.connect(self.db_path)
-        self.conn.execute("PRAGMA journal_mode=WAL")
         
         if self.turbo_mode:
             print("DB: Turbo Mode engaged (Low safety, High speed)")


### PR DESCRIPTION
DuckDB uses MVCC natively and does not support the SQLite-specific 'journal_mode=WAL' configuration. Removing this line resolves the Catalog Error during connection initialization.*